### PR TITLE
docs(readme): add HTTPS deployment clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ For this project, i exploited the following components to build the RAG architec
     ```
 
 8. **Navigate to `http://localhost:5000/`**
+# HTTPS Deployment Note
+
+The application runs over HTTP by default, which is suitable for local development. If the web interface is exposed publicly, HTTPS is recommended to avoid transmitting documents, queries, or API requests in plaintext.
+
+For small-scale or experimental deployments, a free reverse proxy such as Ngrok    can be used to provide HTTPS without modifying the application code. For more stable or long-term deployments, a standard web server (for example, Nginx with TLS) is recommended.
 
 9. **If needed, click on ⚙️ icon to access the admin panel and adjust app parameters**
 


### PR DESCRIPTION
I’m an academic researcher conducting a study on the security of Flask-based AI applications. While reviewing this repository, I noticed that the Flask app appears to be deployed over HTTP without TLS. It’s my recommendation that it be more clear to potential users how to secure API traffic and credentials when the app is accessed remotely.
I’ve submitted a small README update describing why HTTPS is important for deployed Flask apps, along with a couple simple options (ngrok or Nginx) that enables HTTPS with minimal setup for small-scale or development use.
This is not intended as a criticism of the project, only as a practical security improvement suggestion.
